### PR TITLE
Comptime Suggestions

### DIFF
--- a/port/raspberrypi/rp2xxx/src/hal/cpu.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/cpu.zig
@@ -1,0 +1,4 @@
+pub const CPU = enum {
+    RP2040,
+    RP2350,
+};

--- a/port/raspberrypi/rp2xxx/src/hal/pio.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio.zig
@@ -12,7 +12,7 @@ const chip_specific = switch (cpu) {
     .RP2350 => @import("pio/rp2350.zig"),
 };
 pub const StateMachine = common.StateMachine;
-pub const Instruction = common.Instruction;
+pub const Instruction = common.Instruction(cpu);
 pub const PinMapping = common.PinMapping;
 pub const PinMappingOptions = common.PinMappingOptions;
 pub const StateMachineInitOptions = chip_specific.StateMachineInitOptions;
@@ -24,7 +24,9 @@ pub const assembler = @import("pio/assembler.zig");
 const encoder = @import("pio/assembler/encoder.zig");
 
 pub const Program = assembler.Program;
-pub const assemble = assembler.assemble;
+pub inline fn assemble(comptime source: []const u8, comptime options: assembler.AssembleOptions) assembler.Output {
+    return assembler.assemble(cpu, source, options);
+}
 
 pub fn num(n: u2) Pio {
     switch (cpu) {

--- a/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/assembler.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const assert = std.debug.assert;
 
 const CPU = @import("../cpu.zig").CPU;
-// TODO: Isn't this circular?
 const tokenizer = @import("assembler/tokenizer.zig");
 const encoder = @import("assembler/encoder.zig");
 
@@ -73,9 +72,9 @@ pub const Diagnostics = struct {
     }
 };
 
-pub fn assemble_impl(comptime format: Format, comptime source: []const u8, diags: *?Diagnostics, options: AssembleOptions) !Output {
-    const tokens = try tokenizer.tokenize(format, source, diags, options.tokenize);
-    const encoder_output = try encoder.encode(format, tokens.slice(), diags, options.encode);
+pub fn assemble_impl(comptime cpu: CPU, comptime source: []const u8, diags: *?Diagnostics, options: AssembleOptions) !Output {
+    const tokens = try tokenizer.tokenize(cpu, source, diags, options.tokenize);
+    const encoder_output = try encoder.encode(cpu, tokens.slice(), diags, options.encode);
     var programs = std.BoundedArray(Program, options.encode.max_programs).init(0) catch unreachable;
     for (encoder_output.programs.slice()) |bounded|
         try programs.append(bounded.to_exported_program());
@@ -123,25 +122,9 @@ fn format_compile_error(comptime message: []const u8, comptime source: []const u
     });
 }
 
-// TODO: Place. Who should own this?
-pub const Format = enum {
-    RP2040,
-    RP2350,
-};
-
-pub fn cpuToFormat(cpu: CPU) Format {
-    return switch (cpu) {
-        .RP2040 => .RP2040,
-        .RP2350 => .RP2350,
-    };
-}
-
-pub fn assemble(comptime source: []const u8, comptime options: AssembleOptions) Output {
+pub fn assemble(comptime cpu: CPU, comptime source: []const u8, comptime options: AssembleOptions) Output {
     var diags: ?Diagnostics = null;
-    // TODO: We can't import compatibility & zig build test since it depends on microzig
-    // cpuToFormat(cpu) instead of hardcoding
-    // const cpu = @import("../compatibility.zig").cpu;
-    return assemble_impl(.RP2040, source, &diags, options) catch |err| if (diags) |d|
+    return assemble_impl(cpu, source, &diags, options) catch |err| if (diags) |d|
         @compileError(format_compile_error(d.message.slice(), source, d.index))
     else
         @compileError(err);

--- a/port/raspberrypi/rp2xxx/src/hal/pio/rp2040.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/rp2040.zig
@@ -13,6 +13,7 @@ pub const Pio = enum(u1) {
     pio0 = 0,
     pio1 = 1,
 
+    const PioImpl = common.PioImpl(Pio, .RP2040);
     pub fn get_regs(self: Pio) *volatile common.PIO {
         return switch (self) {
             .pio0 => common.PIO0,
@@ -20,7 +21,7 @@ pub const Pio = enum(u1) {
         };
     }
 
-    pub const get_instruction_memory = common.PioImpl(Pio).get_instruction_memory;
+    pub const get_instruction_memory = PioImpl.get_instruction_memory;
 
     pub fn gpio_init(self: Pio, pin: gpio.Pin) void {
         pin.set_function(switch (self) {
@@ -29,15 +30,15 @@ pub const Pio = enum(u1) {
         });
     }
 
-    pub const can_add_program_at_offset = common.PioImpl(Pio).can_add_program_at_offset;
-    pub const find_offset_for_program = common.PioImpl(Pio).find_offset_for_program;
-    pub const add_program_at_offset_unlocked = common.PioImpl(Pio).add_program_at_offset_unlocked;
-    pub const add_program = common.PioImpl(Pio).add_program;
-    pub const claim_unused_state_machine = common.PioImpl(Pio).claim_unused_state_machine;
-    pub const get_sm_regs = common.PioImpl(Pio).get_sm_regs;
-    pub const get_irq_regs = common.PioImpl(Pio).get_irq_regs;
-    pub const sm_set_clkdiv = common.PioImpl(Pio).sm_set_clkdiv;
-    pub const sm_set_exec_options = common.PioImpl(Pio).sm_set_exec_options;
+    pub const can_add_program_at_offset = PioImpl.can_add_program_at_offset;
+    pub const find_offset_for_program = PioImpl.find_offset_for_program;
+    pub const add_program_at_offset_unlocked = PioImpl.add_program_at_offset_unlocked;
+    pub const add_program = PioImpl.add_program;
+    pub const claim_unused_state_machine = PioImpl.claim_unused_state_machine;
+    pub const get_sm_regs = PioImpl.get_sm_regs;
+    pub const get_irq_regs = PioImpl.get_irq_regs;
+    pub const sm_set_clkdiv = PioImpl.sm_set_clkdiv;
+    pub const sm_set_exec_options = PioImpl.sm_set_exec_options;
 
     pub fn sm_set_shift_options(self: Pio, sm: common.StateMachine, options: common.ShiftOptions) void {
         const sm_regs = self.get_sm_regs(sm);
@@ -57,19 +58,19 @@ pub const Pio = enum(u1) {
         });
     }
 
-    pub const sm_set_pin_mappings = common.PioImpl(Pio).sm_set_pin_mappings;
-    pub const sm_set_pindir = common.PioImpl(Pio).sm_set_pindir;
-    pub const sm_set_pin = common.PioImpl(Pio).sm_set_pin;
-    pub const sm_get_rx_fifo = common.PioImpl(Pio).sm_get_rx_fifo;
-    pub const sm_is_rx_fifo_empty = common.PioImpl(Pio).sm_is_rx_fifo_empty;
-    pub const sm_blocking_read = common.PioImpl(Pio).sm_blocking_read;
-    pub const sm_read = common.PioImpl(Pio).sm_read;
-    pub const sm_is_tx_fifo_full = common.PioImpl(Pio).sm_is_tx_fifo_full;
-    pub const sm_get_tx_fifo = common.PioImpl(Pio).sm_get_tx_fifo;
-    pub const sm_write = common.PioImpl(Pio).sm_write;
-    pub const sm_blocking_write = common.PioImpl(Pio).sm_blocking_write;
-    pub const sm_set_enabled = common.PioImpl(Pio).sm_set_enabled;
-    pub const sm_clear_debug = common.PioImpl(Pio).sm_clear_debug;
+    pub const sm_set_pin_mappings = PioImpl.sm_set_pin_mappings;
+    pub const sm_set_pindir = PioImpl.sm_set_pindir;
+    pub const sm_set_pin = PioImpl.sm_set_pin;
+    pub const sm_get_rx_fifo = PioImpl.sm_get_rx_fifo;
+    pub const sm_is_rx_fifo_empty = PioImpl.sm_is_rx_fifo_empty;
+    pub const sm_blocking_read = PioImpl.sm_blocking_read;
+    pub const sm_read = PioImpl.sm_read;
+    pub const sm_is_tx_fifo_full = PioImpl.sm_is_tx_fifo_full;
+    pub const sm_get_tx_fifo = PioImpl.sm_get_tx_fifo;
+    pub const sm_write = PioImpl.sm_write;
+    pub const sm_blocking_write = PioImpl.sm_blocking_write;
+    pub const sm_set_enabled = PioImpl.sm_set_enabled;
+    pub const sm_clear_debug = PioImpl.sm_clear_debug;
 
     /// changing the state of fifos will clear them
     pub fn sm_clear_fifos(self: Pio, sm: common.StateMachine) void {
@@ -93,12 +94,12 @@ pub const Pio = enum(u1) {
         xor_shiftctrl.write(mask);
     }
 
-    pub const sm_fifo_level = common.PioImpl(Pio).sm_fifo_level;
-    pub const sm_clear_interrupt = common.PioImpl(Pio).sm_clear_interrupt;
-    pub const sm_enable_interrupt = common.PioImpl(Pio).sm_enable_interrupt;
-    pub const sm_restart = common.PioImpl(Pio).sm_restart;
-    pub const sm_clkdiv_restart = common.PioImpl(Pio).sm_clkdiv_restart;
-    pub const sm_init = common.PioImpl(Pio).sm_init;
-    pub const sm_exec = common.PioImpl(Pio).sm_exec;
-    pub const sm_load_and_start_program = common.PioImpl(Pio).sm_load_and_start_program;
+    pub const sm_fifo_level = PioImpl.sm_fifo_level;
+    pub const sm_clear_interrupt = PioImpl.sm_clear_interrupt;
+    pub const sm_enable_interrupt = PioImpl.sm_enable_interrupt;
+    pub const sm_restart = PioImpl.sm_restart;
+    pub const sm_clkdiv_restart = PioImpl.sm_clkdiv_restart;
+    pub const sm_init = PioImpl.sm_init;
+    pub const sm_exec = PioImpl.sm_exec;
+    pub const sm_load_and_start_program = PioImpl.sm_load_and_start_program;
 };

--- a/port/raspberrypi/rp2xxx/src/hal/pio/rp2350.zig
+++ b/port/raspberrypi/rp2xxx/src/hal/pio/rp2350.zig
@@ -16,6 +16,8 @@ pub const Pio = enum(u2) {
     pio1 = 1,
     pio2 = 2,
 
+    const PioImpl = common.PioImpl(Pio, .RP2350);
+
     pub fn get_regs(self: Pio) *volatile common.PIO {
         return switch (self) {
             .pio0 => common.PIO0,
@@ -24,7 +26,7 @@ pub const Pio = enum(u2) {
         };
     }
 
-    pub const get_instruction_memory = common.PioImpl(Pio).get_instruction_memory;
+    pub const get_instruction_memory = PioImpl.get_instruction_memory;
 
     pub fn gpio_init(self: Pio, pin: gpio.Pin) void {
         pin.set_function(switch (self) {
@@ -34,15 +36,15 @@ pub const Pio = enum(u2) {
         });
     }
 
-    pub const can_add_program_at_offset = common.PioImpl(Pio).can_add_program_at_offset;
-    pub const find_offset_for_program = common.PioImpl(Pio).find_offset_for_program;
-    pub const add_program_at_offset_unlocked = common.PioImpl(Pio).add_program_at_offset_unlocked;
-    pub const add_program = common.PioImpl(Pio).add_program;
-    pub const claim_unused_state_machine = common.PioImpl(Pio).claim_unused_state_machine;
-    pub const get_sm_regs = common.PioImpl(Pio).get_sm_regs;
-    pub const get_irq_regs = common.PioImpl(Pio).get_irq_regs;
-    pub const sm_set_clkdiv = common.PioImpl(Pio).sm_set_clkdiv;
-    pub const sm_set_exec_options = common.PioImpl(Pio).sm_set_exec_options;
+    pub const can_add_program_at_offset = PioImpl.can_add_program_at_offset;
+    pub const find_offset_for_program = PioImpl.find_offset_for_program;
+    pub const add_program_at_offset_unlocked = PioImpl.add_program_at_offset_unlocked;
+    pub const add_program = PioImpl.add_program;
+    pub const claim_unused_state_machine = PioImpl.claim_unused_state_machine;
+    pub const get_sm_regs = PioImpl.get_sm_regs;
+    pub const get_irq_regs = PioImpl.get_irq_regs;
+    pub const sm_set_clkdiv = PioImpl.sm_set_clkdiv;
+    pub const sm_set_exec_options = PioImpl.sm_set_exec_options;
 
     pub fn sm_set_shift_options(self: Pio, sm: common.StateMachine, options: common.ShiftOptions) void {
         const sm_regs = self.get_sm_regs(sm);
@@ -66,19 +68,19 @@ pub const Pio = enum(u2) {
         });
     }
 
-    pub const sm_set_pin_mappings = common.PioImpl(Pio).sm_set_pin_mappings;
-    pub const sm_set_pindir = common.PioImpl(Pio).sm_set_pindir;
-    pub const sm_set_pin = common.PioImpl(Pio).sm_set_pin;
-    pub const sm_get_rx_fifo = common.PioImpl(Pio).sm_get_rx_fifo;
-    pub const sm_is_rx_fifo_empty = common.PioImpl(Pio).sm_is_rx_fifo_empty;
-    pub const sm_blocking_read = common.PioImpl(Pio).sm_blocking_read;
-    pub const sm_read = common.PioImpl(Pio).sm_read;
-    pub const sm_is_tx_fifo_full = common.PioImpl(Pio).sm_is_tx_fifo_full;
-    pub const sm_get_tx_fifo = common.PioImpl(Pio).sm_get_tx_fifo;
-    pub const sm_write = common.PioImpl(Pio).sm_write;
-    pub const sm_blocking_write = common.PioImpl(Pio).sm_blocking_write;
-    pub const sm_set_enabled = common.PioImpl(Pio).sm_set_enabled;
-    pub const sm_clear_debug = common.PioImpl(Pio).sm_clear_debug;
+    pub const sm_set_pin_mappings = PioImpl.sm_set_pin_mappings;
+    pub const sm_set_pindir = PioImpl.sm_set_pindir;
+    pub const sm_set_pin = PioImpl.sm_set_pin;
+    pub const sm_get_rx_fifo = PioImpl.sm_get_rx_fifo;
+    pub const sm_is_rx_fifo_empty = PioImpl.sm_is_rx_fifo_empty;
+    pub const sm_blocking_read = PioImpl.sm_blocking_read;
+    pub const sm_read = PioImpl.sm_read;
+    pub const sm_is_tx_fifo_full = PioImpl.sm_is_tx_fifo_full;
+    pub const sm_get_tx_fifo = PioImpl.sm_get_tx_fifo;
+    pub const sm_write = PioImpl.sm_write;
+    pub const sm_blocking_write = PioImpl.sm_blocking_write;
+    pub const sm_set_enabled = PioImpl.sm_set_enabled;
+    pub const sm_clear_debug = PioImpl.sm_clear_debug;
 
     /// changing the state of fifos will clear them
     pub fn sm_clear_fifos(self: Pio, sm: common.StateMachine) void {
@@ -105,12 +107,12 @@ pub const Pio = enum(u2) {
         xor_shiftctrl.write(mask);
     }
 
-    pub const sm_fifo_level = common.PioImpl(Pio).sm_fifo_level;
-    pub const sm_clear_interrupt = common.PioImpl(Pio).sm_clear_interrupt;
-    pub const sm_enable_interrupt = common.PioImpl(Pio).sm_enable_interrupt;
-    pub const sm_restart = common.PioImpl(Pio).sm_restart;
-    pub const sm_clkdiv_restart = common.PioImpl(Pio).sm_clkdiv_restart;
-    pub const sm_init = common.PioImpl(Pio).sm_init;
-    pub const sm_exec = common.PioImpl(Pio).sm_exec;
-    pub const sm_load_and_start_program = common.PioImpl(Pio).sm_load_and_start_program;
+    pub const sm_fifo_level = PioImpl.sm_fifo_level;
+    pub const sm_clear_interrupt = PioImpl.sm_clear_interrupt;
+    pub const sm_enable_interrupt = PioImpl.sm_enable_interrupt;
+    pub const sm_restart = PioImpl.sm_restart;
+    pub const sm_clkdiv_restart = PioImpl.sm_clkdiv_restart;
+    pub const sm_init = PioImpl.sm_init;
+    pub const sm_exec = PioImpl.sm_exec;
+    pub const sm_load_and_start_program = PioImpl.sm_load_and_start_program;
 };


### PR DESCRIPTION
- Removed the `Format` type as you splitting out `CPU` type into a different file to avoid the compile error made me realize we can just use the `CPU` type directly
- Various simplifications/reorganizations to make this scheme work!